### PR TITLE
add option 'threshold' representing % of different pixels (number between 0 and 100)

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -73,7 +73,7 @@ ImageDiff.createDiff = function (options, cb) {
     // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
     // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
     // TODO: This is not very multi-lengual =(
-    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((.*?)\)/);
+    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((\d+\.?\d*e?\-?\d*)\)/);
 
     // If there was no resultInfo, throw a fit
     if (!resultInfo) {
@@ -81,8 +81,12 @@ ImageDiff.createDiff = function (options, cb) {
     }
 
     // Callback with pass/fail
-    var totalDifference = resultInfo[2]; // this is the percentage difference
-    return cb(null, parseFloat(totalDifference) <= options.threshold, options.diffPath);
+    var percentDifference = parseFloat(resultInfo[2], 10);
+    var threshold = (typeof(options.threshold) === 'undefined' || isNaN(parseFloat(options.threshold, 10))) ? 0.0 : parseFloat(options.threshold);
+    if (isNaN(percentDifference)) {
+      return cb(new Error('Attempted to parse percentage difference from `image-diff\'s stderr` but got `NaN` from "' + resultInfo[2] + '"'));
+    }
+    return cb(null, percentDifference <= threshold);
   });
 };
 ImageDiff.prototype = {
@@ -190,9 +194,8 @@ ImageDiff.prototype = {
           expectedPath: expectedTmpPath,
           diffPath: diffPath,
           threshold: threshold
-        }, function saveResult (err, _imagesAreSame, _diffPath) {
+        }, function saveResult (err, _imagesAreSame) {
           imagesAreSame = _imagesAreSame;
-          diffPath = _diffPath;
           cb(err);
         });
       }
@@ -205,7 +208,7 @@ ImageDiff.prototype = {
         fs.unlink(filepath, cb);
       }, function callOriginalCallback (_err) {
         // Callback with the imagesAreSame
-        callback(err, imagesAreSame, diffPath);
+        callback(err, imagesAreSame);
       });
     });
   }

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -82,7 +82,7 @@ ImageDiff.createDiff = function (options, cb) {
 
     // Callback with pass/fail
     var percentDifference = parseFloat(resultInfo[2], 10);
-    var threshold = (typeof(options.threshold) === 'undefined' || isNaN(parseFloat(options.threshold, 10))) ? 0.0 : parseFloat(options.threshold);
+    var threshold = options.threshold || 0;
     if (isNaN(percentDifference)) {
       return cb(new Error('Attempted to parse percentage difference from `image-diff\'s stderr` but got `NaN` from "' + resultInfo[2] + '"'));
     }

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -73,7 +73,7 @@ ImageDiff.createDiff = function (options, cb) {
     // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
     // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
     // TODO: This is not very multi-lengual =(
-    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((\d+\.?\d*)\)/);
+    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((.*?)\)/);
 
     // If there was no resultInfo, throw a fit
     if (!resultInfo) {
@@ -81,8 +81,8 @@ ImageDiff.createDiff = function (options, cb) {
     }
 
     // Callback with pass/fail
-    var totalDifference = resultInfo[1];
-    return cb(null, totalDifference === '0');
+    var totalDifference = resultInfo[2]; // this is the percentage difference
+    return cb(null, parseFloat(totalDifference) <= options.threshold, options.diffPath);
   });
 };
 ImageDiff.prototype = {
@@ -91,6 +91,7 @@ ImageDiff.prototype = {
     var actualPath = options.actualImage;
     var expectedPath = options.expectedImage;
     var diffPath = options.diffImage;
+    var threshold = options.threshold;
 
     // Assert our options are passed in
     if (!actualPath) {
@@ -187,9 +188,11 @@ ImageDiff.prototype = {
         ImageDiff.createDiff({
           actualPath: actualTmpPath,
           expectedPath: expectedTmpPath,
-          diffPath: diffPath
-        }, function saveResult (err, _imagesAreSame) {
+          diffPath: diffPath,
+          threshold: threshold
+        }, function saveResult (err, _imagesAreSame, _diffPath) {
           imagesAreSame = _imagesAreSame;
+          diffPath = _diffPath;
           cb(err);
         });
       }
@@ -202,7 +205,7 @@ ImageDiff.prototype = {
         fs.unlink(filepath, cb);
       }, function callOriginalCallback (_err) {
         // Callback with the imagesAreSame
-        callback(err, imagesAreSame);
+        callback(err, imagesAreSame, diffPath);
       });
     });
   }

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -32,7 +32,7 @@ describe('image-diff', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
       expectedImage: __dirname + '/test-files/white.png',
-      diffImage: __dirname + '/actual-files/different.png',
+      diffImage: __dirname + '/actual-files/different.png'
     });
     imageUtils.loadActual('different.png');
     imageUtils.loadExpected('different.png');
@@ -68,7 +68,7 @@ describe('image-diff', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard-excess.png',
       expectedImage: __dirname + '/test-files/checkerboard.png',
-      diffImage: __dirname + '/actual-files/different-size.png',
+      diffImage: __dirname + '/actual-files/different-size.png'
     });
     imageUtils.loadActual('different-size.png');
     imageUtils.loadExpected('different-size.png');

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -31,7 +31,7 @@ describe('image-diff', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
       expectedImage: __dirname + '/test-files/white.png',
-      diffImage: __dirname + '/actual-files/different.png'
+      diffImage: __dirname + '/actual-files/different.png',
     });
     imageUtils.loadActual('different.png');
     imageUtils.loadExpected('different.png');
@@ -45,12 +45,51 @@ describe('image-diff', function () {
     });
   });
 
+  describe('diffing different images using lower threshold', function () {
+    runImageDiff({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/white.png',
+      diffImage: __dirname + '/actual-files/different.png',
+      threshold: 0.7
+    });
+    imageUtils.loadActual('different.png');
+    imageUtils.loadExpected('different.png');
+
+    it('asserts images are different', function () {
+      assert.strictEqual(this.imagesAreSame, false);
+    });
+
+    it('writes a highlighted image diff to disk', function () {
+      assert.deepEqual(this.actualPixels, this.expectedPixels);
+    });
+  });
+
+  describe('diffing different images using higher threshold', function () {
+    runImageDiff({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/white.png',
+      diffImage: __dirname + '/actual-files/different2.png',
+      threshold: 0.8
+    });
+    imageUtils.loadActual('different2.png');
+    imageUtils.loadExpected('different.png');
+
+    it('asserts images are different', function () {
+      assert.strictEqual(this.imagesAreSame, true);
+    });
+
+    it('writes a highlighted image diff to disk', function () {
+      assert.deepEqual(this.actualPixels, this.expectedPixels);
+    });
+  });
+
   describe('diffing the same image', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
       expectedImage: __dirname + '/test-files/checkerboard.png',
       diffImage: __dirname + '/actual-files/same.png'
     });
+
     imageUtils.loadActual('same.png');
     imageUtils.loadExpected('same.png');
 
@@ -67,7 +106,8 @@ describe('image-diff', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard-excess.png',
       expectedImage: __dirname + '/test-files/checkerboard.png',
-      diffImage: __dirname + '/actual-files/different-size.png'
+      diffImage: __dirname + '/actual-files/different-size.png',
+      threshold: 0.70
     });
     imageUtils.loadActual('different-size.png');
     imageUtils.loadExpected('different-size.png');

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -45,14 +45,14 @@ describe('image-diff', function () {
     });
   });
 
-  describe('diffing different images using lower threshold', function () {
+  describe('diffing different images over a threshold', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
       expectedImage: __dirname + '/test-files/white.png',
-      diffImage: __dirname + '/actual-files/different.png',
-      threshold: 0.7
+      diffImage: __dirname + '/actual-files/over-threshold.png',
+      threshold: 0.2
     });
-    imageUtils.loadActual('different.png');
+    imageUtils.loadActual('over-threshold.png');
     imageUtils.loadExpected('different.png');
 
     it('asserts images are different', function () {
@@ -64,17 +64,17 @@ describe('image-diff', function () {
     });
   });
 
-  describe('diffing different images using higher threshold', function () {
+  describe('diffing different images under a threshold', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
       expectedImage: __dirname + '/test-files/white.png',
-      diffImage: __dirname + '/actual-files/different2.png',
-      threshold: 0.8
+      diffImage: __dirname + '/actual-files/under-threshold.png',
+      threshold: 0.9
     });
-    imageUtils.loadActual('different2.png');
+    imageUtils.loadActual('under-threshold.png');
     imageUtils.loadExpected('different.png');
 
-    it('asserts images are different', function () {
+    it('asserts images are similar enough', function () {
       assert.strictEqual(this.imagesAreSame, true);
     });
 
@@ -89,7 +89,6 @@ describe('image-diff', function () {
       expectedImage: __dirname + '/test-files/checkerboard.png',
       diffImage: __dirname + '/actual-files/same.png'
     });
-
     imageUtils.loadActual('same.png');
     imageUtils.loadExpected('same.png');
 

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -23,6 +23,7 @@ rimraf.sync(__dirname + '/actual-files');
 // DEV: This is re-used at end to make sure we clean up tmp files
 var tmpDir = os.tmpdir ? os.tmpdir() : '/tmp';
 before(function () {
+  this.timeout(5000);
   this.expectedTmpFiles = fs.readdirSync(tmpDir);
 });
 

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -45,6 +45,66 @@ describe('image-diff', function () {
     });
   });
 
+  describe('diffing the same image', function () {
+    runImageDiff({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/checkerboard.png',
+      diffImage: __dirname + '/actual-files/same.png'
+    });
+    imageUtils.loadActual('same.png');
+    imageUtils.loadExpected('same.png');
+
+    it('asserts images are the same', function () {
+      assert.strictEqual(this.imagesAreSame, true);
+    });
+
+    it('writes a clean image diff to disk', function () {
+      assert.deepEqual(this.actualPixels, this.expectedPixels);
+    });
+  });
+
+  describe('diffing different sizes images', function () {
+    runImageDiff({
+      actualImage: __dirname + '/test-files/checkerboard-excess.png',
+      expectedImage: __dirname + '/test-files/checkerboard.png',
+      diffImage: __dirname + '/actual-files/different-size.png',
+    });
+    imageUtils.loadActual('different-size.png');
+    imageUtils.loadExpected('different-size.png');
+
+    it('asserts images are different', function () {
+      assert.strictEqual(this.err, null);
+      assert.strictEqual(this.imagesAreSame, false);
+    });
+
+    it('writes a highlighted image diff to disk', function () {
+      assert.deepEqual(this.actualPixels, this.expectedPixels);
+    });
+  });
+
+  // DEV: This is a regression test for https://github.com/uber/image-diff/pull/10
+  describe('diffing images which cannot scale into each other', function () {
+    var diffImage = __dirname + '/actual-files/horizontal-vertical.png';
+    runImageDiff({
+      actualImage: __dirname + '/test-files/horizontal.png',
+      expectedImage: __dirname + '/test-files/vertical.png',
+      diffImage: diffImage
+    });
+    imageUtils.loadActual('horizontal-vertical.png');
+    imageUtils.loadExpected('horizontal-vertical.png');
+
+    it('asserts images are different', function () {
+      assert.strictEqual(this.err, null);
+      assert.strictEqual(this.imagesAreSame, false);
+    });
+
+    it('writes an image diff to disk', function () {
+      var diffExists = fs.existsSync(diffImage);
+      assert.strictEqual(diffExists, true);
+      assert.deepEqual(this.actualPixels, this.expectedPixels);
+    });
+  });
+
   describe('diffing different images over a threshold', function () {
     runImageDiff({
       actualImage: __dirname + '/test-files/checkerboard.png',
@@ -79,67 +139,6 @@ describe('image-diff', function () {
     });
 
     it('writes a highlighted image diff to disk', function () {
-      assert.deepEqual(this.actualPixels, this.expectedPixels);
-    });
-  });
-
-  describe('diffing the same image', function () {
-    runImageDiff({
-      actualImage: __dirname + '/test-files/checkerboard.png',
-      expectedImage: __dirname + '/test-files/checkerboard.png',
-      diffImage: __dirname + '/actual-files/same.png'
-    });
-    imageUtils.loadActual('same.png');
-    imageUtils.loadExpected('same.png');
-
-    it('asserts images are the same', function () {
-      assert.strictEqual(this.imagesAreSame, true);
-    });
-
-    it('writes a clean image diff to disk', function () {
-      assert.deepEqual(this.actualPixels, this.expectedPixels);
-    });
-  });
-
-  describe('diffing different sizes images', function () {
-    runImageDiff({
-      actualImage: __dirname + '/test-files/checkerboard-excess.png',
-      expectedImage: __dirname + '/test-files/checkerboard.png',
-      diffImage: __dirname + '/actual-files/different-size.png',
-      threshold: 0.70
-    });
-    imageUtils.loadActual('different-size.png');
-    imageUtils.loadExpected('different-size.png');
-
-    it('asserts images are different', function () {
-      assert.strictEqual(this.err, null);
-      assert.strictEqual(this.imagesAreSame, false);
-    });
-
-    it('writes a highlighted image diff to disk', function () {
-      assert.deepEqual(this.actualPixels, this.expectedPixels);
-    });
-  });
-
-  // DEV: This is a regression test for https://github.com/uber/image-diff/pull/10
-  describe('diffing images which cannot scale into each other', function () {
-    var diffImage = __dirname + '/actual-files/horizontal-vertical.png';
-    runImageDiff({
-      actualImage: __dirname + '/test-files/horizontal.png',
-      expectedImage: __dirname + '/test-files/vertical.png',
-      diffImage: diffImage
-    });
-    imageUtils.loadActual('horizontal-vertical.png');
-    imageUtils.loadExpected('horizontal-vertical.png');
-
-    it('asserts images are different', function () {
-      assert.strictEqual(this.err, null);
-      assert.strictEqual(this.imagesAreSame, false);
-    });
-
-    it('writes an image diff to disk', function () {
-      var diffExists = fs.existsSync(diffImage);
-      assert.strictEqual(diffExists, true);
       assert.deepEqual(this.actualPixels, this.expectedPixels);
     });
   });


### PR DESCRIPTION
Threshold should be a value between 0 and 100 (% of pixels that are
different). Should take into account that compare.exe sometimes returns normalized numbers of kind 9.9999e-999) 