### PR TITLE
Dropped node@0.8 and added node@0.12/iojs to fix Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: node_js
 node_js:
+  - "0.12"
   - "0.11"
   - "0.10"
-  - "0.8"
+  - "iojs"
 matrix:
   allow_failures:
     - node_js: "0.11"


### PR DESCRIPTION
The current Travis CI configuration is failing for `node@0.8`. Fortunately, `node@0.10` was released about 2 years ago so it is safe to drop support for `node@0.8`. In this PR:

- Dropped `node@0.8` in Travis CI
- Added `node@0.12` and `iojs` in Travis CI

/cc @Raynos @mlmorg 