### PR TITLE
Added release script and documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # image-diff changelog
+1.0.2 - Added release script and documentation
+
 1.0.1 - Added example image to README
 
 1.0.0 - Moved to consistently use ImageMagick and fixed scaling regression (#11)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,25 @@
+# Releasing
+Releases are done via `foundry` to guarantee consistent sets of changes across developers. To perform a release:
+
+1. Update the `CHANGELOG.md` with a message (if not done so in the PR)
+
+2. Stage changes
+    ```bash
+    git add -p
+    ```
+
+3. Run `./release.sh {{semver}}`
+    ```bash
+    ./release.sh {{semver}}
+    # For example:
+    # ./release.sh 1.2.0
+    ```
+
+    Under the hood, `./release.sh` will:
+
+    1. Update the version in `package.json`
+    2. Create a new `git commit` for "Release 1.2.0"
+    3. Create `git tag` for `1.2.0`
+    4. Push `master` branch
+    5. Push git tags
+    6. Publish to `npm`

--- a/package.json
+++ b/package.json
@@ -36,12 +36,15 @@
     "shell-quote": "~1.4.1"
   },
   "devDependencies": {
-    "mocha": "~1.11.0",
+    "foundry": "~3.1.0",
+    "foundry-release-git": "~1.1.0",
+    "foundry-release-npm": "~1.1.0",
+    "get-pixels": "~1.0.1",
     "grunt": "~0.4.1",
+    "grunt-cli": "~0.1.11",
     "grunt-contrib-jshint": "~0.6.0",
     "grunt-contrib-watch": "~0.4.0",
-    "get-pixels": "~1.0.1",
-    "grunt-cli": "~0.1.11",
+    "mocha": "~1.11.0",
     "rimraf": "~2.2.6"
   },
   "keywords": [

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Exit on first error
+set -e
+
+# Run foundry with arguments
+./node_modules/.bin/foundry release $*


### PR DESCRIPTION
As discussed in #16, this PR adds a `release.sh` to help with making releases consistent. For documentation, I have added a `RELEASING.md`. Additionally, I have added mlmorg as an owner to `image-diff` in `npm`.

In this PR:

- Added release script
- Added documentation for releasing

/cc @mlmorg 