### PR TITLE
Added support for no output image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # image-diff changelog
+1.1.0 - Added support for no output image
+
 1.0.3 - Repaired Travis CI tests by dropping `node@0.8` and adding `node@0.12`/`iojs`
 
 1.0.2 - Added release script and documentation

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Create an differential image between multiple images
         - options.actualImage **must** exist
     - options.expectedImage `String` - Path to expected image file
         - If options.expectedImage does not exist, a transparent image with the same height/width will be created.
-    - options.diffImage `String` - Path to output differential image
+    - options.diffImage `String` - Optional path to output differential image
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint via [grunt](https://github.com/gruntjs/grunt) and test via `npm test`.

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -1,9 +1,9 @@
-var exec = require('child_process').exec;
+// Load in our dependencies
 var fs = require('fs');
 var path = require('path');
 var async = require('async');
 var gm = require('gm').subClass({imageMagick: true});
-var shellQuote = require('shell-quote');
+var bufferedSpawn = require('buffered-spawn');
 var mkdirp = require('mkdirp');
 var tmp = require('tmp');
 
@@ -52,7 +52,8 @@ ImageDiff.getImageSize = function (filepath, cb) {
 };
 ImageDiff.createDiff = function (options, cb) {
   // http://www.imagemagick.org/script/compare.php
-  var diffCmd = shellQuote.quote([
+  var diffCmd = 'compare';
+  var diffArgs = [
     'compare',
     '-verbose',
     // TODO: metric and highlight could become constructor options
@@ -61,9 +62,12 @@ ImageDiff.createDiff = function (options, cb) {
     '-compose', 'Src',
     options.actualPath,
     options.expectedPath,
-    options.diffPath
-  ]);
-  exec(diffCmd, function processDiffOutput (err, stdout, stderr) {
+    // If there is no output image, then output to `stdout` (which is ignored)
+    options.diffPath || '-'
+  ];
+  // Ignore `stdin` and `stdout` (useful for ignoring when images are being sent to stdout)
+  var spawnOptions = {stdio: ['ignore', 'ignore', 'pipe']};
+  bufferedSpawn(diffCmd, diffArgs, spawnOptions, function processDiffOutput (err, stdout, stderr) {
     // If we failed with no info, callback
     if (err && !stderr) {
       return cb(err);
@@ -101,11 +105,6 @@ ImageDiff.prototype = {
     if (!expectedPath) {
       return process.nextTick(function () {
         callback(new Error('`options.expectedPath` was not passed to `image-diff`'));
-      });
-    }
-    if (!diffPath) {
-      return process.nextTick(function () {
-        callback(new Error('`options.diffPath` was not passed to `image-diff`'));
       });
     }
 
@@ -179,9 +178,13 @@ ImageDiff.prototype = {
       },
       function createDiffDirectory (/*..., cb*/) {
         var cb = [].slice.call(arguments, -1)[0];
-        mkdirp(path.dirname(diffPath), function (err) {
-          cb(err);
-        });
+        if (diffPath) {
+          mkdirp(path.dirname(diffPath), function (err) {
+            cb(err);
+          });
+        } else {
+          process.nextTick(cb);
+        }
       },
       function createDiff (cb) {
         ImageDiff.createDiff({

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   },
   "dependencies": {
     "async": "~0.2.9",
+    "buffered-spawn": "~1.1.1",
     "gm": "~1.13.3",
     "mkdirp": "~0.3.5",
-    "tmp": "0.0.23",
-    "shell-quote": "~1.4.1"
+    "tmp": "0.0.23"
   },
   "devDependencies": {
     "foundry": "~3.1.0",

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -82,6 +82,18 @@ describe('image-diff', function () {
     });
   });
 
+  describe('diffing different images without an output image', function () {
+    runImageDiff({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/white.png'
+    });
+
+    it('asserts images are different', function () {
+      assert.strictEqual(this.err, null);
+      assert.strictEqual(this.imagesAreSame, false);
+    });
+  });
+
   // DEV: This is a regression test for https://github.com/uber/image-diff/pull/10
   describe('diffing images which cannot scale into each other', function () {
     var diffImage = __dirname + '/actual-files/horizontal-vertical.png';


### PR DESCRIPTION
**Depends on https://github.com/bower/buffered-spawn/pull/5**

As requested in #23, we should support no output image. This PR adds support for that by sending the diff image to `stdout` and ignoring `stdout`. In this PR:

- Added test for no diff image
- Removed assertions for `options.diffImage`
- Moved to `buffered-spawn` which supports ignoring `stdout`

Once again, this depends on https://github.com/bower/buffered-spawn/pull/5 so please don't land it until that PR has been landed/released and this PR has been updated to use that version.

/cc @mlmorg 