### PR TITLE
Fix case where alpha value is an exponent

### DIFF
--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -79,7 +79,7 @@ ImageDiff.createDiff = function (options, cb) {
     // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
     // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
     // TODO: This is not very multi-lengual =(
-    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((\d+\.?\d*)\)/);
+    var resultInfo = stderr.match(/all: (\d+(?:\.\d+)?) \((\d+(?:\.\d+)?(?:[Ee]-?\d+)?)\)/);
 
     // If there was no resultInfo, throw a fit
     if (!resultInfo) {


### PR DESCRIPTION
From error,

```
! Exception ocurred when performing image diff for tiedChords-ipad-pro-portrait@1-p1
[Error: Expected `image-diff's stderr` to contain 'all' but received "/tmp/tmp-76818mswa0g.png PNG 1024x1366 1024x1366+0+0 8-bit DirectClass 14.2KB 0.010u 0:00.019
/tmp/tmp-76818m6035c.png PNG 1024x1366 1024x1366+0+0 8-bit DirectClass 14.2KB 0.010u 0:00.019
Image: /tmp/tmp-76818mswa0g.png
  Channel distortion: RMSE
    gray: 0.532272 (8.12195e-06)
    alpha: 0 (0)
    all: 0.460961 (7.03381e-06)
/tmp/tmp-76818mswa0g.png=>artifacts/diff/features/tie/tiedChords-ipad-pro-portrait@1-p1.png PNG 1024x1366 1024x1366+0+0 8-bit PseudoClass 3c 0.150u 0:00.149
"]
```