### PR TITLE
Abstracted `extractDifference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # image-diff changelog
+1.3.0 - Fixed support for fractional differences via @jacobp100 in #29
+
 1.2.0 - Added support for showing shadow image in diff image via @064678147 in #25
 
 1.1.0 - Added support for no output image

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -50,6 +50,20 @@ ImageDiff.getImageSize = function (filepath, cb) {
     });
   });
 };
+ImageDiff.extractDifference = function (output) {
+  // Attempt to find variant between 'all: 0 (0)', 'all: 40131.8 (0.612372)', or 'all: 0.460961 (7.03381e-06)'
+  // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
+  // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
+  // TODO: This is not very multi-lengual =(
+  var resultInfo = output.match(/all: (\d+(?:\.\d+)?(?:[Ee]-?\d+)?) \((\d+(?:\.\d+)?(?:[Ee]-?\d+)?)\)/);
+  if (!resultInfo) {
+    throw new Error('Expected output to contain \'all\' but received "' + output + '"');
+  }
+  return {
+    total: resultInfo[1],
+    percentage: resultInfo[2]
+  };
+};
 ImageDiff.createDiff = function (options, cb) {
   // http://www.imagemagick.org/script/compare.php
   var diffCmd = 'compare';
@@ -75,20 +89,9 @@ ImageDiff.createDiff = function (options, cb) {
       return cb(err);
     }
 
-    // Attempt to find variant between 'all: 0 (0)' or 'all: 40131.8 (0.612372)'
-    // DEV: According to http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
-    // DEV: These values are the total square root mean square (RMSE) pixel difference across all pixels and its percentage
-    // TODO: This is not very multi-lengual =(
-    var resultInfo = stderr.match(/all: (\d+\.?\d*) \((\d+\.?\d*)\)/);
-
-    // If there was no resultInfo, throw a fit
-    if (!resultInfo) {
-      return cb(new Error('Expected `image-diff\'s stderr` to contain \'all\' but received "' + stderr + '"'));
-    }
-
-    // Callback with pass/fail
-    var totalDifference = resultInfo[1];
-    return cb(null, totalDifference === '0');
+    // Grab the total different and callback with pass/fail
+    var difference = ImageDiff.extractDifference(stderr);
+    return cb(null, difference.total === '0');
   });
 };
 ImageDiff.prototype = {

--- a/test/extract-total-difference_test.js
+++ b/test/extract-total-difference_test.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var ImageDiff = require('../lib/image-diff.js').ImageDiff;
+
+describe('An image-diff output with no difference', function () {
+  describe('when extracted via `extractDifference`', function () {
+    it('extracts no difference', function () {
+      var difference = ImageDiff.extractDifference('all: 0 (0)');
+      assert.strictEqual(difference.total, '0');
+      assert.strictEqual(difference.percentage, '0');
+    });
+  });
+});
+
+describe('An image-diff output with a significant difference', function () {
+  describe('when extracted via `extractDifference`', function () {
+    it('extracts the significant difference', function () {
+      var difference = ImageDiff.extractDifference('all: 40131.8 (0.612372)');
+      assert.strictEqual(difference.total, '40131.8');
+      assert.strictEqual(difference.percentage, '0.612372');
+    });
+  });
+});
+
+describe('An image-diff output with a fractional difference', function () {
+  describe('when extracted via `extractDifference`', function () {
+    it('extracts the fractional difference', function () {
+      var difference = ImageDiff.extractDifference('all: 0.460961 (7.03381e-06)');
+      assert.strictEqual(difference.total, '0.460961');
+      assert.strictEqual(difference.percentage, '7.03381e-06');
+    });
+  });
+});
+
+// DEV: This is an edge case we haven't encountered but want to be extra safe
+describe('An image-diff output with a super fractional difference', function () {
+  describe('when extracted via `extractDifference`', function () {
+    it('extracts the fractional difference', function () {
+      var difference = ImageDiff.extractDifference('all: 7.03381e-06 (7.03381e-06)');
+      assert.strictEqual(difference.total, '7.03381e-06');
+      assert.strictEqual(difference.percentage, '7.03381e-06');
+    });
+  });
+});


### PR DESCRIPTION
**Depends on #29**

We have another edge case for ImageMagick output from #29. This PR makes the fixes more testable and adds tests. In this PR:

- Relocated output handling to `ImageDiff.extractDifference`
- Added tests for all existing cases and new potential case
- Updated CHANGELOG

@mlmorg This should be good to deploy in a minor update.

```bash
./release.sh 1.3.0
```