### PR TITLE
Added `getFullResult` and `getRawResult` methods

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -16,6 +16,7 @@
     "exports": true,
     "describe": true,
     "before": true,
+    "after": true,
     "it": true
   }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # image-diff changelog
+1.6.0 - Added `getFullResult` and `getRawResult` methods
+
 1.5.1 - Upgraded to `gm@1.21.1` to resolve security advisory via @jacobp100 in #38
 
 1.5.0 - Added `image-diff` executable

--- a/README.md
+++ b/README.md
@@ -33,9 +33,9 @@ imageDiff({
 ```
 
 ## Documentation
-`image-diff` exposes a function for you to callback with.
+`image-diff` exposes the function `imageDiff` as its export.
 
-### `diffImages(options, cb)`
+### `imageDiff(options, cb)`
 Create an differential image between multiple images
 
 - options `Object`
@@ -47,6 +47,47 @@ Create an differential image between multiple images
     - options.shadow `Boolean` - Optional flag to indicate if we should draw a shadow of the unchanged parts of the images
         - For example, if an image is `+` and we diff with `-`, then the image will have `|` be red but also contain a faded `-`
         - By default, this options is `false` meaning a shadow will not be drawn
+- cb `Function` - Error-first function to handle diff result
+    - `cb` should have the signature `function (err, imagesAreSame)`
+    - err `Error|null` - If there was an error in diffing, this will be it
+    - imagesAreSame `Boolean` - Indicates that images are same or not
+
+### `imageDiff.getFullResult(options, cb)`
+Same as `imageDiff` but yields a fuller result
+
+- options `Object` - See `imageDiff#options`
+- cb `Function` - Error-first function to handle diff result
+    - `cb` should have the signature `function (err, result)`
+    - err `Error|null` - If there was an error in diffing, this will be it
+    - result `Object`
+        - total `Float` - Root mean square pixel difference across all pixels
+          - Value can range from 0 (no difference) to 655535 (every pixel is different)
+        - percentage `Float` - Normalized total difference
+          - Value can range from 0.00 (no difference) to 1.00 (every pixel is different)
+        - More info here: http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
+
+**Example:**
+
+```javascript
+var imageDiff = require('image-diff');
+imageDiff.getFullResult({
+  actualImage: 'checkerboard.png',
+  expectedImage: 'white.png',
+  diffImage: 'difference.png',
+}, function (err, result) {
+  // result = {total: 46340.2, difference: 0.707107}
+});
+```
+
+### `imageDiff.getRawResult(options, cb)`
+Same as `imageDiff` but yields raw CLI result
+
+- options `Object` - See `imageDiff#options`
+- cb `Function` - Error-first function to handle diff result
+    - `cb` should have the signature `function (err, result)`
+    - err `Error|null` - If there was an error in diffing, this will be it
+    - result `String` - Result from ImageMagick's `compare` command
+        - Example output can be found here: http://www.imagemagick.org/discourse-server/viewtopic.php?f=1&t=17284
 
 ### CLI usage
 We offer an `image-diff` executable to diff from the CLI. When images match, its exit code will be `0`. When they don't match, then it will be non-zero (e.g. `1`).

--- a/lib/image-diff.js
+++ b/lib/image-diff.js
@@ -8,6 +8,10 @@ var bufferedSpawn = require('buffered-spawn');
 var mkdirp = require('mkdirp');
 var tmp = require('tmp');
 
+// DEV: If we want to restructure away from a class
+//   I (@twolfson) suggest writing to `exports` (e.g. `exports.getBooleanResult`, `exports.getFullResult`)
+//   then making `module.exports = _.extend(exports.getBooleanResult, exports);`
+
 // Define custom resize function
 function transparentExtent(gm, params) {
   // Assert we received our parameters
@@ -61,8 +65,8 @@ ImageDiff.extractDifference = function (output) {
     throw new Error('Expected output to contain \'all\' but received "' + output + '"');
   }
   return {
-    total: resultInfo[1],
-    percentage: resultInfo[2]
+    total: parseFloat(resultInfo[1], 10),
+    percentage: parseFloat(resultInfo[2], 10)
   };
 };
 ImageDiff.createDiff = function (options, cb) {
@@ -90,13 +94,12 @@ ImageDiff.createDiff = function (options, cb) {
       return cb(err);
     }
 
-    // Grab the total different and callback with pass/fail
-    var difference = ImageDiff.extractDifference(stderr);
-    return cb(null, difference.total === '0');
+    // Callback with raw result
+    return cb(null, stderr);
   });
 };
 ImageDiff.prototype = {
-  diff: function (options, callback) {
+  rawDiff: function (options, callback) {
     // TODO: Break this down more...
     var actualPath = options.actualImage;
     var expectedPath = options.expectedImage;
@@ -117,7 +120,7 @@ ImageDiff.prototype = {
 
     var actualTmpPath;
     var expectedTmpPath;
-    var imagesAreSame;
+    var rawResult;
     async.waterfall([
       function assertActualPathExists (cb) {
         fs.exists(actualPath, function handleActualExists (actualExists) {
@@ -195,8 +198,8 @@ ImageDiff.prototype = {
           expectedPath: expectedTmpPath,
           diffPath: diffPath,
           shadow: shadow
-        }, function saveResult (err, _imagesAreSame) {
-          imagesAreSame = _imagesAreSame;
+        }, function saveResult (err, _rawResult) {
+          rawResult = _rawResult;
           cb(err);
         });
       }
@@ -208,19 +211,51 @@ ImageDiff.prototype = {
       async.forEach(cleanupPaths, function cleanupFile (filepath, cb) {
         fs.unlink(filepath, cb);
       }, function callOriginalCallback (_err) {
-        // Callback with the imagesAreSame
-        callback(err, imagesAreSame);
+        // Callback with the raw result
+        callback(err, rawResult);
       });
+    });
+  },
+  fullDiff: function (options, cb) {
+    // Create a raw diff
+    this.rawDiff(options, function handleRawDiff (err, rawResult) {
+      // If there was an error, callback with it
+      if (err) {
+        return cb(err);
+      }
+
+      // Otherwise, parse the result and callback
+      cb(null, ImageDiff.extractDifference(rawResult));
+    });
+  },
+  diff: function (options, cb) {
+    // Create a full diff
+    this.fullDiff(options, function handleFullDiff (err, difference) {
+      // If there was an error, callback with it
+      if (err) {
+        return cb(err);
+      }
+
+      // Otherwise, validate the difference and callback
+      cb(null, difference.total === 0);
     });
   }
 };
 
-// Create helper utility
-function diffImages(options, cb) {
+// Create helper utilities
+function imageDiff(options, cb) {
   var differ = new ImageDiff();
   differ.diff(options, cb);
 }
+imageDiff.getFullResult = function (options, cb) {
+  var differ = new ImageDiff();
+  differ.fullDiff(options, cb);
+};
+imageDiff.getRawResult = function (options, cb) {
+  var differ = new ImageDiff();
+  differ.rawDiff(options, cb);
+};
 
 // Export the original class and helper
-diffImages.ImageDiff = ImageDiff;
-module.exports = diffImages;
+imageDiff.ImageDiff = ImageDiff;
+module.exports = imageDiff;

--- a/test/extract-total-difference_test.js
+++ b/test/extract-total-difference_test.js
@@ -5,8 +5,8 @@ describe('An image-diff output with no difference', function () {
   describe('when extracted via `extractDifference`', function () {
     it('extracts no difference', function () {
       var difference = ImageDiff.extractDifference('all: 0 (0)');
-      assert.strictEqual(difference.total, '0');
-      assert.strictEqual(difference.percentage, '0');
+      assert.strictEqual(difference.total, 0);
+      assert.strictEqual(difference.percentage, 0);
     });
   });
 });
@@ -15,8 +15,8 @@ describe('An image-diff output with a significant difference', function () {
   describe('when extracted via `extractDifference`', function () {
     it('extracts the significant difference', function () {
       var difference = ImageDiff.extractDifference('all: 40131.8 (0.612372)');
-      assert.strictEqual(difference.total, '40131.8');
-      assert.strictEqual(difference.percentage, '0.612372');
+      assert.strictEqual(difference.total, 40131.8);
+      assert.strictEqual(difference.percentage, 0.612372);
     });
   });
 });
@@ -25,8 +25,8 @@ describe('An image-diff output with a fractional difference', function () {
   describe('when extracted via `extractDifference`', function () {
     it('extracts the fractional difference', function () {
       var difference = ImageDiff.extractDifference('all: 0.460961 (7.03381e-06)');
-      assert.strictEqual(difference.total, '0.460961');
-      assert.strictEqual(difference.percentage, '7.03381e-06');
+      assert.strictEqual(difference.total, 0.460961);
+      assert.strictEqual(difference.percentage, 7.03381e-06);
     });
   });
 });
@@ -36,8 +36,8 @@ describe('An image-diff output with a super fractional difference', function () 
   describe('when extracted via `extractDifference`', function () {
     it('extracts the fractional difference', function () {
       var difference = ImageDiff.extractDifference('all: 7.03381e-06 (7.03381e-06)');
-      assert.strictEqual(difference.total, '7.03381e-06');
-      assert.strictEqual(difference.percentage, '7.03381e-06');
+      assert.strictEqual(difference.total, 7.03381e-06);
+      assert.strictEqual(difference.percentage, 7.03381e-06);
     });
   });
 });

--- a/test/image-diff-get-full-result_test.js
+++ b/test/image-diff-get-full-result_test.js
@@ -1,0 +1,45 @@
+var assert = require('assert');
+var imageDiff = require('../lib/image-diff.js');
+
+function getFullResult(options) {
+  before(function (done) {
+    var that = this;
+    imageDiff.getFullResult(options, function (err, fullResult) {
+      that.err = err;
+      that.fullResult = fullResult;
+      done();
+    });
+  });
+  after(function cleanup () {
+    delete this.err;
+    delete this.fullResult;
+  });
+}
+
+describe('imageDiff.getFullResult', function () {
+  describe('diffing different images', function () {
+    getFullResult({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/white.png',
+      diffImage: __dirname + '/actual-files/different.png'
+    });
+
+    it('calls back with differences in full result', function () {
+      assert.strictEqual(this.fullResult.total, 46340.2);
+      assert.strictEqual(this.fullResult.percentage, 0.707107);
+    });
+  });
+
+  describe('diffing the same image', function () {
+    getFullResult({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/checkerboard.png',
+      diffImage: __dirname + '/actual-files/same.png'
+    });
+
+    it('calls back with no differences in full result', function () {
+      assert.strictEqual(this.fullResult.total, 0);
+      assert.strictEqual(this.fullResult.percentage, 0);
+    });
+  });
+});

--- a/test/image-diff-get-raw-result_test.js
+++ b/test/image-diff-get-raw-result_test.js
@@ -1,0 +1,43 @@
+var assert = require('assert');
+var imageDiff = require('../lib/image-diff.js');
+
+function getRawResult(options) {
+  before(function (done) {
+    var that = this;
+    imageDiff.getRawResult(options, function (err, rawResult) {
+      that.err = err;
+      that.rawResult = rawResult;
+      done();
+    });
+  });
+  after(function cleanup () {
+    delete this.err;
+    delete this.rawResult;
+  });
+}
+
+describe('imageDiff.getRawResult', function () {
+  describe('diffing different images', function () {
+    getRawResult({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/white.png',
+      diffImage: __dirname + '/actual-files/different.png'
+    });
+
+    it('calls back with differences in the raw result', function () {
+      assert(this.rawResult.indexOf('all: 46340.2 (0.707107)') !== -1);
+    });
+  });
+
+  describe('diffing the same image', function () {
+    getRawResult({
+      actualImage: __dirname + '/test-files/checkerboard.png',
+      expectedImage: __dirname + '/test-files/checkerboard.png',
+      diffImage: __dirname + '/actual-files/same.png'
+    });
+
+    it('calls back with no differences in the raw result', function () {
+      assert(this.rawResult.indexOf('all: 0 (0)') !== -1);
+    });
+  });
+});

--- a/test/image-diff_test.js
+++ b/test/image-diff_test.js
@@ -14,6 +14,10 @@ function runImageDiff(options) {
       done();
     });
   });
+  after(function cleanup () {
+    delete this.err;
+    delete this.imagesAreSame;
+  });
 }
 
 // Clean up actual-files


### PR DESCRIPTION
In #39 we want to add support for retrieving percentages. In order to handle that and future-proof `image-diff` for further cases, we are adding methods which call back with the raw CLI info from ImageMagick and extracted total/percentage info.

In this PR:

- Added `getFullResult` and `getRawResult` methods
- Added tests
- Updated/added documentation
- Added missing context cleanup in tests (e.g. `after(function cleanup () {`)
- Fixes #39 

**Notes:**

For release, this should be as simple as:

```bash
./release.sh 1.6.0
```

/cc @mlmorg 