### PR TITLE
$* will undergo word splitting and pathname expansion

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -3,4 +3,4 @@
 set -e
 
 # Run foundry with arguments
-./node_modules/.bin/foundry release $*
+./node_modules/.bin/foundry release "$@"


### PR DESCRIPTION
I changed `$*` to `"$@"` which will expand parameters as passed and prevent pathname expansion, consider this snippet:
```
~ $ cat test.sh
#!/usr/bin/env bash
printf "<%s>" $*
printf "\n"
printf "<%s>" "$*"
printf "\n"
printf "<%s>" "$@"
printf "\n"
~ $ ./test.sh 'hello world' 'John' 'Doe'
<hello><world><John><Doe>
<hello world John Doe>
<hello world><John><Doe>
```

Above each send argument for `printf` is wrapped in `<...>`. `"$@"` is the only expansion that respects the send arguments.

If we run the same test with a literal `*` the result will be something like:

```
~ $ ./test.sh '*'
<bin><Desktop><Documents><Downloads><...><...>
<*>
<*>
```